### PR TITLE
Fix invalid reference to `AstroElectron` in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,7 +97,7 @@ console.log("preload.ts");
 ```javascript
 export default defineConfig({
   integrations: [
-    astroElectron({
+    electron({
       main: {
         entry: "src/electron/main.ts", // Path to your Electron main file
         vite: {}, // Vite-specific configurations (by default we use the same config as your Astro project)


### PR DESCRIPTION
Pretty sure this should be `electron`, as `AstroElectron` does not seem to appear anywhere else in the code